### PR TITLE
Support for two contracts + mutable baseURI

### DIFF
--- a/.openzeppelin/staging.json
+++ b/.openzeppelin/staging.json
@@ -1,0 +1,245 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0x847645b7dAA32eFda757d3c10f1c82BFbB7b41D0",
+      "txHash": "0x95540a545c9c95b9adab703c7dfbb6236e0ae25f580f619e77147105df13b15e",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "1dd496c110c76e6c4a09a936d545cf45f37cd15a67321ef4b718e3993a452fd5": {
+      "address": "0xB16B902886ede51F308AB0f31a163F4247FBe122",
+      "txHash": "0x6887c3632a36b2f9bb8597aaf1eec16419c63c25bfda94c1f2da863f63850443",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:37"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:42"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:25"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:28"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_owners",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:31"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:34"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenApprovals",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:37"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:40"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)44_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:431"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokens",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:25"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:28"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokens",
+            "type": "t_array(t_uint256)dyn_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:34"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)46_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:172"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:97"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
+          },
+          {
+            "contract": "ERC721BurnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol:35"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:215"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:81"
+          },
+          {
+            "contract": "TablelandTables",
+            "label": "_tokenIdCounter",
+            "type": "t_struct(Counter)2859_storage",
+            "src": "contracts/Registry.sol:28"
+          },
+          {
+            "contract": "TablelandTables",
+            "label": "_baseURIString",
+            "type": "t_string_storage",
+            "src": "contracts/Registry.sol:31"
+          }
+        ],
+        "types": {
+          "t_struct(Counter)2859_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)43_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.openzeppelin/testnet.json
+++ b/.openzeppelin/testnet.json
@@ -461,6 +461,239 @@
           }
         }
       }
+    },
+    "1dd496c110c76e6c4a09a936d545cf45f37cd15a67321ef4b718e3993a452fd5": {
+      "address": "0x44F3c1494bb92b9Fda3f9534b30E3D68d6545972",
+      "txHash": "0x00014e345bf15b621d274813d1bf3d5bd616469be4ebf36694260cb1620cc11a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:37"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:42"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:25"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:28"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_owners",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:31"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:34"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenApprovals",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:37"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:40"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)44_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:431"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokens",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:25"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:28"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokens",
+            "type": "t_array(t_uint256)dyn_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:34"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)46_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:172"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:97"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
+          },
+          {
+            "contract": "ERC721BurnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol:35"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:215"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:81"
+          },
+          {
+            "contract": "TablelandTables",
+            "label": "_tokenIdCounter",
+            "type": "t_struct(Counter)2859_storage",
+            "src": "contracts/Registry.sol:28"
+          },
+          {
+            "contract": "TablelandTables",
+            "label": "_baseURIString",
+            "type": "t_string_storage",
+            "src": "contracts/Registry.sol:31"
+          }
+        ],
+        "types": {
+          "t_struct(Counter)2859_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)43_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -28,7 +28,9 @@ contract TablelandTables is
     CountersUpgradeable.Counter private _tokenIdCounter;
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
-    function initialize() public initializer {
+    string private _baseURIString;
+
+    function initialize(string memory baseURI) public initializer {
         __ERC721_init("Tableland Tables", "TABLE");
         __ERC721Enumerable_init();
         __Pausable_init();
@@ -39,10 +41,19 @@ contract TablelandTables is
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);
+
+        setBaseURI(baseURI);
     }
 
-    function _baseURI() internal pure override returns (string memory) {
-        return "https://testnet.tableland.network/tables/";
+    function setBaseURI(string memory baseURI)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _baseURIString = baseURI;
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _baseURIString;
     }
 
     function pause() public onlyRole(PAUSER_ROLE) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@textile/eth-tableland",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@textile/eth-tableland",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ethersproject/providers": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/eth-tableland",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "On-chain ETH registry and client components for Tableland",
   "main": "typechain/index.js",
   "types": "typechain/index.d.ts",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,19 +6,25 @@
 import { ethers, upgrades } from "hardhat";
 
 async function main() {
-  // Hardhat always runs the compile task when running scripts with its command
-  // line interface.
-  //
-  // If this script is run directly using `node` you may want to call compile
-  // manually to make sure everything is compiled
-  // await hre.run('compile');
-
-  // We get the contract (proxy) to deploy
   const Registry = await ethers.getContractFactory("TablelandTables");
-  const registry = await upgrades.deployProxy(Registry, [], {
-    kind: "uups",
-  });
-  console.log("Proxy deployed to:", registry.address);
+
+  // const testnet = await upgrades.deployProxy(
+  //   Registry,
+  //   ["https://testnet.tableland.network/tables/"],
+  //   {
+  //     kind: "uups",
+  //   }
+  // );
+  // console.log("Testnet proxy deployed to:", testnet.address);
+
+  const staging = await upgrades.deployProxy(
+    Registry,
+    ["https://staging.tableland.network/tables/"],
+    {
+      kind: "uups",
+    }
+  );
+  console.log("Staging proxy deployed to:", staging.address);
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,13 +1,19 @@
 import { ethers, upgrades } from "hardhat";
 
-const proxyAddress = "0x30867AD98A520287CCc28Cde70fCF63E3Cdb9c3C";
+const testnetProxy = "0x30867AD98A520287CCc28Cde70fCF63E3Cdb9c3C";
+const stagingProxy = "0x847645b7dAA32eFda757d3c10f1c82BFbB7b41D0";
 
 async function main() {
   const Registry = await ethers.getContractFactory("TablelandTables");
-  await upgrades.upgradeProxy(proxyAddress, Registry, {
+  await upgrades.upgradeProxy(testnetProxy, Registry, {
     kind: "uups",
   });
-  console.log("Proxy upgraded");
+  console.log("Testnet proxy upgraded");
+
+  await upgrades.upgradeProxy(stagingProxy, Registry, {
+    kind: "uups",
+  });
+  console.log("Staging proxy upgraded");
 }
 
 main().catch((error) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,7 +14,7 @@ describe("Registry", function () {
     registry = await Factory.deploy();
     await registry.deployed();
     // Manually call initialize because we are "deploying" the contract directly.
-    await registry.initialize();
+    await registry.initialize("https://website.com/");
   });
 
   it("Should mint a new table", async function () {
@@ -29,6 +29,17 @@ describe("Registry", function () {
     expect(1).to.equal(Number(balance.toString()));
     const totalSupply = await registry.totalSupply();
     expect(1).to.equal(Number(totalSupply.toString()));
+  });
+
+  it("Should udpate the base URI", async function () {
+    let tx = await registry.setBaseURI("https://fake.com/");
+    await tx.wait();
+
+    const target = accounts[4].address;
+    tx = await registry.safeMint(target);
+    await tx.wait();
+    const tokenURI = await registry.tokenURI(0);
+    expect(tokenURI).includes("https://fake.com/");
   });
 
   it("Should be easy to await the transaction", async function () {

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -6,12 +6,41 @@ describe("Proxy", function () {
   it(" Should be callable from deployed proxy contract", async function () {
     const Factory = await ethers.getContractFactory("TablelandTables");
 
-    const registry = (await upgrades.deployProxy(Factory, [], {
-      kind: "uups",
-    })) as TablelandTables;
+    const registry = (await upgrades.deployProxy(
+      Factory,
+      ["https://fake.com/"],
+      {
+        kind: "uups",
+      }
+    )) as TablelandTables;
     await registry.deployed();
 
     const totalSupply = await registry.totalSupply();
     expect(0).to.equal(Number(totalSupply.toString()));
+  });
+
+  it(" Should be able to deploy two proxy contracts with different baseURI", async function () {
+    const [account] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory("TablelandTables");
+
+    const reg1 = (await upgrades.deployProxy(Factory, ["https://one.com/"], {
+      kind: "uups",
+    })) as TablelandTables;
+    await reg1.deployed();
+
+    const reg2 = (await upgrades.deployProxy(Factory, ["https://two.com/"], {
+      kind: "uups",
+    })) as TablelandTables;
+    await reg2.deployed();
+
+    expect(reg1.address).to.not.equal(reg2.address);
+    const totalSupply = await reg1.totalSupply();
+    expect(0).to.equal(Number(totalSupply.toString()));
+
+    const tx = await reg1.safeMint(account.address);
+    await tx.wait();
+
+    const tokenURI = await reg1.tokenURI(0);
+    expect(tokenURI).to.include("https://one.com/");
   });
 });


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Summary

This PR adds support for two contracts deployed to rinkeby testnet. There is some manual fiddling about to get this to work, so beware if you want to do upgrades or deployments for individual instances.

## Details

Essentially, we have to manage the "history" of the upgrades over time. This is done automatically via open zeppelin tooling, but we have to be careful because we have multiple deployments of the same contract to rinkeby (the norm is to have just one per network).

## How it was tested

I've added some new tests to make sure that we can a) mutate the baseURI, and b) deploy the same contract twice with different addresses.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
