### PR TITLE
feat: update name to @tableland scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Textile
+Copyright (c) 2021-2022 Tableland Network Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# eth-tableland
+# @tableland/eth
 
-[![GitHub license](https://img.shields.io/github/license/textileio/eth-tableland.svg)](./LICENSE)
-[![GitHub package.json version](https://img.shields.io/github/package-json/v/textileio/eth-tableland.svg)](./package.json)
-[![Release](https://img.shields.io/github/release/textileio/eth-tableland.svg)](https://github.com/textileio/eth-tableland/releases/latest)
+[![GitHub license](https://img.shields.io/github/license/tablelandnetwork/eth-tableland.svg)](./LICENSE)
+[![GitHub package.json version](https://img.shields.io/github/package-json/v/tablelandnetwork/eth-tableland.svg)](./package.json)
+[![Release](https://img.shields.io/github/release/tablelandnetwork/eth-tableland.svg)](https://github.com/tablelandnetwork/eth-tableland/releases/latest)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg)](https://github.com/RichardLitt/standard-readme)
 
-![Tests](https://github.com/textileio/eth-tableland/workflows/Test/badge.svg)
+![Tests](https://github.com/tablelandnetwork/eth-tableland/workflows/Test/badge.svg)
 
 > On-chain ETH registry and client components for Tableland
 
@@ -130,4 +130,4 @@ Small note: If editing the README, please conform to the
 
 # License
 
-MIT AND Apache-2.0, © 2021-2022 Textile.io
+MIT AND Apache-2.0, © 2021-2022 Tableland Network Contributors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@textile/eth-tableland",
-  "version": "0.0.3",
+  "name": "@tableland/eth",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@textile/eth-tableland",
-      "version": "0.0.3",
+      "name": "@tableland/eth",
+      "version": "0.0.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ethersproject/providers": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@textile/eth-tableland",
-  "version": "0.0.3",
+  "name": "@tableland/eth",
+  "version": "0.0.1",
   "description": "On-chain ETH registry and client components for Tableland",
   "main": "typechain/index.js",
   "types": "typechain/index.d.ts",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textileio/eth-tableland.git"
+    "url": "git+https://github.com/tablelandnetwork/eth-tableland.git"
   },
   "keywords": [
     "tableland",
@@ -25,12 +25,11 @@
     "contract",
     "textile"
   ],
-  "author": "Carson Farmer <carson@textile.io>",
   "license": "MIT AND Apache-2.0",
   "bugs": {
-    "url": "https://github.com/textileio/eth-tableland/issues"
+    "url": "https://github.com/tablelandnetwork/eth-tableland/issues"
   },
-  "homepage": "https://github.com/textileio/eth-tableland#readme",
+  "homepage": "https://github.com/tablelandnetwork/eth-tableland#readme",
   "dependencies": {
     "@ethersproject/providers": "^5.5.0",
     "ethers": "^5.5.1"
@@ -68,5 +67,9 @@
     "ts-node": "^10.4.0",
     "typechain": "^5.2.0",
     "typescript": "^4.5.2"
-  }
+  },
+  "contributors": [
+    "Carson Farmer <carson@textile.io>",
+    "Aaron Sutula <aaron@textile.io>"
+  ]
 }


### PR DESCRIPTION
Renames the npm package to the `@tableland` scope. Additionally changes to a contributors list, and renames some of the underlying deps. This should be merged before the corresponding changes to `tablelandnetwork/js-tableland` have been made.

For reviewers, please make sure the npm stuff is scoped to `@tableland`, whereas all the GitHub stuff is scoped to `@tablelandnetwork`.